### PR TITLE
Add thrift diff api

### DIFF
--- a/thrift_tools/tests/test_diff.py
+++ b/thrift_tools/tests/test_diff.py
@@ -1,0 +1,76 @@
+import unittest
+
+from thrift_tools.thrift_diff import ThriftDiff as Diff
+from thrift_tools.thrift_message import ThriftMessage
+from thrift_tools.thrift_struct import ThriftStruct, ThriftField
+
+
+class ThriftDiffTestCase(unittest.TestCase):
+    def test_is_diff_compatible(self):
+        def _diff_compatibility(msg1, msg2, allowed):
+            ok_to_diff, reason = Diff.can_diff(msg1, msg2)
+            if allowed:
+                self.assertTrue(ok_to_diff, reason)
+            else:
+                self.assertFalse(ok_to_diff)
+                self.assertIsNotNone(reason)
+
+        # Method name doesn't match
+        rpc1 = ThriftMessage("ping", None, None, ThriftStruct([]))
+        rpc2 = ThriftMessage("pong", None, None, ThriftStruct([]))
+        _diff_compatibility(rpc1, rpc2, False)
+
+        # Method names match, so does argument signature
+        rpc1 = ThriftMessage("ping", None, None,
+                             ThriftStruct([ThriftField("string", 1, "a")]))
+        rpc2 = ThriftMessage("ping", None, None,
+                             ThriftStruct([ThriftField("string", 1, "b")]))
+        _diff_compatibility(rpc1, rpc2, True)
+
+        # Method names match, but argument signature is different
+        rpc1 = ThriftMessage("ping", None, None,
+                             ThriftStruct([ThriftField("string", 1, "a")]))
+        rpc2 = ThriftMessage("ping", None, None,
+                             ThriftStruct([ThriftField("i32", 1, "b")]))
+        _diff_compatibility(rpc1, rpc2, False)
+
+    def test_diff_of_structs(self):
+        f1 = ThriftField("string", 1, "one")
+        f2 = ThriftField("i32", 2, 2)
+        f3 = ThriftField("bool", 3, True)
+        f4 = ThriftField("i32", 2, 4)
+        s1 = ThriftStruct([f1, f2, f3])
+        s2 = ThriftStruct([f1, f4])
+
+        t_diff = Diff.of_structs(s1, s2)
+        self.assertListEqual([(f1, f1), (f2, f4)], t_diff.common_fields)
+        self.assertListEqual([f1], t_diff.fields_with_same_value)
+        self.assertEqual(1, len(t_diff._fields_with_different_value))
+        self.assertListEqual([f3], t_diff.fields_only_in_a)
+        self.assertTrue(len(t_diff.fields_only_in_b) == 0)
+
+    def test_diff_of_messages(self):
+        f1 = ThriftField("string", 1, "one")
+        f2 = ThriftField("i32", 2, 2)
+        s1 = ThriftStruct([f1])
+        s2 = ThriftStruct([f2])
+        m1 = ThriftMessage("ping", "call", 1, s1)
+        m2 = ThriftMessage("ping", "call", 2, s2)
+        with self.assertRaisesRegexp(ValueError, 'argument signature'):
+            Diff.of_messages(m1, m2)
+
+        # Diff messages with all primitive args
+        self.assertEqual(0, len(Diff.of_messages(m1, m1)),
+                         "Message based diff only consider args of type struct")
+
+        # Diff messages with mixed type of args
+        f3 = ThriftField("struct", 1, ThriftStruct([f1, f2]))
+        m3 = ThriftMessage("ping", "call", 2, ThriftStruct([f1, f2, f3, f3]))
+        diffs = Diff.of_messages(m3, m3)
+        self.assertEqual(2, len(diffs))
+
+        # We diffed identical messages, verify that diff reflects that
+        self.assertListEqual([f1, f2], diffs[0].fields_with_same_value)
+        self.assertEqual(0, len(diffs[0].field_with_different_value))
+
+

--- a/thrift_tools/thrift_diff.py
+++ b/thrift_tools/thrift_diff.py
@@ -1,0 +1,140 @@
+"""
+    Diff thrift structures & messages
+
+    Examples:
+        > while not finished:
+                msg_a, _ = ThriftMessage.read(data_stream_a, read_values=True)
+                msg_b, _ = ThriftMessage.read(data_stream_b, read_values=True)
+                args_diff = ThriftDiff.of_messages(msg_a, msg_b)
+                for diff in args_diff:
+                    print diff.common_fields()
+        [(ThriftField(field_type=str, field_id=1, value="hello world"),
+            ThriftField(field_type=str, field_id=1, value="bye world"))]
+
+        > t_diff = ThriftDiff.of_structs(struct_a, struct_b)
+        > print t_diff.fields_with_same_value()
+        ThriftField(field_type=str, field_id=1, value="hello world")
+    """
+
+
+class ThriftDiff:
+
+    def __init__(self, struct_a, struct_b):
+        self._a = struct_a
+        self._b = struct_b
+        self._common_fields = []
+        self._fields_only_in_a = []
+        self._fields_only_in_b = []
+        self._fields_with_different_value = []
+        self._fields_with_same_value = []
+
+    @classmethod
+    def of_structs(cls, a, b):
+        """
+        Diff two thrift structs and return the result as a ThriftDiff instance
+        """
+        t_diff = ThriftDiff(a, b)
+        t_diff._do_diff()
+        return t_diff
+
+    @classmethod
+    def of_messages(cls, msg_a, msg_b):
+        """
+        Diff two thrift messages by comparing their args, raises exceptions if
+        for some reason the messages can't be diffed. Only args of type 'struct'
+        are compared.
+
+        Returns a list of ThriftDiff results - one for each struct arg
+        """
+        ok_to_diff, reason = cls.can_diff(msg_a, msg_b)
+        if not ok_to_diff:
+            raise ValueError(reason)
+        return [cls.of_structs(x.value, y.value)
+                for x, y in zip(msg_a.args, msg_b.args)
+                if x.field_type == 'struct']
+
+    @staticmethod
+    def can_diff(msg_a, msg_b):
+        """
+        Check if two thrift messages are diff ready.
+
+        Returns a tuple of (boolean, reason_string), i.e. (False, reason_string)
+        if the messages can not be diffed along with the reason and
+        (True, None) for the opposite case
+        """
+        if msg_a.method != msg_b.method:
+            return False, 'method name of messages do not match'
+        if len(msg_a.args) != len(msg_b.args) \
+                or not msg_a.args.is_isomorphic_to(msg_b.args):
+            return False, 'argument signature of methods do not match'
+        return True, None
+
+    def _do_diff(self):
+        self._common_fields = [(x, y)
+                               for x, y in zip(self._a.fields, self._b.fields)
+                               if x.is_isomorphic_to(y)]
+        self._fields_only_in_a = self._unique_fields(self._common_fields,
+                                                     self._a.fields)
+        self._fields_only_in_b = self._unique_fields(self._common_fields,
+                                                     self._b.fields)
+        # Go over the common fields and filter them into two sets, one for
+        # the case when field values match and other for the ones where they
+        # don't match
+        for field_pair in self._common_fields:
+            if field_pair[0] == field_pair[1]:
+                # For common fields with same values, just record one of the
+                # fields in the pair
+                self._fields_with_same_value.append(field_pair[0])
+            else:
+                self._fields_with_different_value.append(field_pair)
+
+    @staticmethod
+    def _unique_fields(common_fields, all_fields):
+        unique_fields = []
+        for x in all_fields:
+            is_unique = True
+            for field_pair in common_fields:
+                if x.is_isomorphic_to(field_pair[0]):
+                    is_unique = False
+                    break
+            if is_unique:
+                unique_fields.append(x)
+        return unique_fields
+
+    @property
+    def common_fields(self):
+        """
+        List of isomorphically equivalent field pairs which may or may not have
+        same value
+        """
+        return self._common_fields
+
+    @property
+    def fields_only_in_a(self):
+        """
+        List of fields exclusive to first struct
+        """
+        return self._fields_only_in_a
+
+    @property
+    def fields_only_in_b(self):
+        """
+        List of fields exclusive to second struct
+        """
+        return self._fields_only_in_b
+
+    @property
+    def fields_with_same_value(self):
+        """
+        List of isomorphically equivalent fields for which value is also equal
+        Note: this doesn't return a list of 'pairs'
+        """
+        return self._fields_with_same_value
+
+    @property
+    def field_with_different_value(self):
+        """
+        List of isomorphically equivalent field pairs for which value is NOT
+        equal
+        """
+        return self._fields_with_different_value

--- a/thrift_tools/thrift_struct.py
+++ b/thrift_tools/thrift_struct.py
@@ -36,8 +36,8 @@ class ThriftStruct(object):
     def __iter__(self):
         return iter(self._fields)
 
-    def __str__(self):
-        return str(self._fields)
+    def __repr__(self):
+        return "fields=%s" % self.fields
 
     class ObjectTooBig(Exception):
         pass
@@ -52,6 +52,7 @@ class ThriftStruct(object):
              read_values=False):
         fields = []
         nfields = 0
+        proto.readStructBegin()
         while True:
             nfields += 1
             if nfields >= max_fields:
@@ -72,7 +73,7 @@ class ThriftStruct(object):
             proto.readFieldEnd()
 
             fields.append(ThriftField(cls.field_type_to_str(ftype), fid, value))
-
+        proto.readStructEnd()
         return cls(fields)
 
     @classmethod
@@ -108,7 +109,6 @@ class ThriftStruct(object):
         #        the transport seek() to that point.
 
         if ftype == TType.STRUCT:
-            proto.readStructBegin()
             value = cls.read(
                 proto,
                 max_fields,
@@ -117,7 +117,6 @@ class ThriftStruct(object):
                 max_set_size,
                 read_values
             )
-            proto.readStructEnd()
         elif ftype == TType.I32:
             if read_values:
                 value = proto.readI32()
@@ -232,8 +231,8 @@ class ThriftField(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def __str__(self):
-        return 'field_type=%s, field_id=%s, value=%s' % (
+    def __repr__(self):
+        return '(%s, %s, %s)' % (
             self.field_type, self.field_id, self._value)
 
     def is_isomorphic_to(self, other):


### PR DESCRIPTION
Add thrift diff api which can diff two thrift structs or two thrift
messages. The result is reported as ThriftDiff data structure which
contains diff details of two types (a) fields which look 'similar' by virtue
of their meta data & (b) fields which are exactly same in terms of both
meta data and actual data

This change also add some basic unit tests for the diff api.