### PR TITLE
Add support for Thrift IDL parsing and printing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ below):
     $ cd thrift-tools
     $ sudo FROM_SOURCE=1 bin/thrift-tool --iface=eth0 --port 9091 dump --show-all --pretty
     ...
+    $ FROM_SOURCE=1 bin/thrift-tool --port 9090 \
+        --pcap-file thrift_tools/tests/resources/calc-service-binary.pcap \
+        dump --show-all --pretty --color \
+        --idl-file=thrift_tools/tests/resources/tutorial.thrift
 
 Tools
 ~~~~~
@@ -115,6 +119,13 @@ command:
     search2        61  0.00860996  0.00636292  0.0188479   0.010778    0.015192    0.0174422   0.0187074
     doc            39  0.00134846  0.00099802  0.00274897  0.00177183  0.00199242  0.00256242  0.00273031
     287 unmatched calls
+
+You can also specify .thrift file for nicer output:
+
+::
+
+    $ sudo thrift-tool --port 9091 dump --show-all --pretty --color --idl-file /path/to/myidl.thrift
+    ...
 
 To list all the available options:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 ansicolors
 dpkt==1.9.2
 nose
+ply==3.11
+ptsd==0.2.0
 scapy==2.4.2
 six==1.12.0
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
       install_requires=[
           'ansicolors',
           'dpkt==1.9.2',
+          'ptsd==0.2.0',
           'scapy==2.4.2',
           'thrift==0.11.0',
           'tabulate',
@@ -59,6 +60,7 @@ setup(
           'ansicolors',
           'dpkt',
           'nose',
+          'ptsd==0.2.0',
           'scapy==2.4.2',
           'six==1.12.0',
           'thrift==0.11.0',
@@ -69,6 +71,7 @@ setup(
               'ansicolors',
               'dpkt',
               'nose',
+              'ptsd==0.2.0',
               'scapy==2.4.2',
               'six==1.12.0',
               'thrift==0.11.0',

--- a/thrift_tools/idl.py
+++ b/thrift_tools/idl.py
@@ -1,0 +1,331 @@
+import os
+
+from ptsd import ast
+from ptsd.parser import Parser
+
+
+class IdlNode(object):
+    def __repr__(self):
+        return "%s(%s)" % (
+            type(self).__name__,
+            ", ".join("%s=%s" % item for item in vars(self).items()),
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class Type(IdlNode):
+    def parse(self, value):
+        pass
+
+
+class Void(Type):
+    pass
+
+
+class TypeDef(Type):
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+
+
+class Enum(Type):
+    def __init__(self, name, values):
+        self.name = name
+        self.values = values
+        self.names_by_tags = dict((value, name) for (name, value) in self.values)
+
+    def parse(self, value):
+        return self.names_by_tags[value]
+
+
+class Field(IdlNode):
+    def __init__(self, tag, name, is_required, type):
+        self.tag = tag
+        self.name = name
+        self.is_required = is_required
+        self.type = type
+
+
+class Struct(Type):
+    def __init__(self, name, fields):
+        self.name = name
+        self.fields = fields
+        self.fields_by_tags = dict((x.tag, x) for x in self.fields)
+
+    def parse(self, fields):
+        struct_fields = []
+
+        fields_by_tag = dict((x.field_id, x) for x in fields)
+
+        for field_def in self.fields:
+            value = None
+
+            field = fields_by_tag.get(field_def.tag)
+
+            if field is not None:
+                value = field.value
+
+                if isinstance(field_def.type, Type):
+                    value = field_def.type.parse(value)
+
+            struct_fields.append((field_def.name, value))
+
+        return (self.name, struct_fields)
+
+
+class Exc(Struct):
+    pass
+
+
+class List(Type):
+    def __init__(self, type):
+        self.type = type
+
+    def parse(self, values):
+        list_values = []
+
+        for value in values:
+            if isinstance(self.type, Type):
+                value = self.type.parse(value)
+
+            list_values.append(value)
+
+        return list_values
+
+
+class Set(Type):
+    def __init__(self, type):
+        self.type = type
+
+    def parse(self, values):
+        set_values = set()
+
+        for value in values:
+            if isinstance(self.type, Type):
+                value = self.type.parse(value)
+
+            set_values.add(value)
+
+        return set_values
+
+
+class Map(Type):
+    def __init__(self, key_type, value_type):
+        self.key_type = key_type
+        self.value_type = value_type
+
+    def parse(self, map):
+        map_values = {}
+
+        for key, value in map.items():
+            if isinstance(self.key_type, Type):
+                key = self.key_type.parse(key)
+            if isinstance(self.value_type, Type):
+                value = self.value_type.parse(value)
+
+            map_values[key] = value
+
+        return map_values
+
+
+class Function(IdlNode):
+    def __init__(self, name, arguments, type, throws):
+        self.name = name
+        self.arguments = arguments
+        self.arguments_by_tags = dict((x.tag, x) for x in self.arguments)
+        self.type = type
+        self.throws = throws
+        self.throws_by_tags = dict((x.tag, x) for x in self.throws)
+
+    def get_args(self, msg):
+        if msg.type == "call":
+            args = []
+
+            args_by_tag = dict((x.field_id, x) for x in msg.args)
+
+            for arg in self.arguments:
+                value = args_by_tag.get(arg.tag).value
+
+                if isinstance(arg.type, Type):
+                    value = arg.type.parse(value)
+
+                args.append((arg.name, value))
+
+            return args
+
+        if msg.type == "reply":
+            if msg.args:
+                if msg.args[0].field_id == 0:  # return
+                    value = msg.args[0].value
+
+                    if isinstance(self.type, Type):
+                        value = self.type.parse(value)
+
+                    return value
+
+                value = msg.args[0].value
+                throw_type = self.throws_by_tags[msg.args[0].field_id].type
+
+                if isinstance(throw_type, Type):
+                    value = throw_type.parse(value)
+
+                return value
+
+        return msg.args
+
+
+class Idl(object):
+    def __init__(self, functions):
+        self.functions = functions
+        self.functions_by_name = dict((x.name, x) for x in self.functions)
+
+    def get_function(self, name):
+        return self.functions_by_name.get(name, None)
+
+
+class IdlParser(object):
+    def __init__(self):
+        self.functions = []
+        self.types_by_name = {}
+
+    def parse_file(self, path):
+        with open(path, "r") as thrift_file:
+            tree = Parser().parse(thrift_file.read())
+
+        for include in tree.includes:
+            include_path = os.path.join(os.path.dirname(path), include.path.value)
+
+            self.parse_file(include_path)
+
+        self.parse_body(tree.body)
+
+    def resolve_type(self, node_type):
+        if isinstance(node_type, ast.Identifier):
+            resolved_type = self.types_by_name[node_type.value]
+
+            if isinstance(resolved_type, TypeDef):
+                return self.resolve_type(resolved_type.node_type)
+
+            return resolved_type
+        if isinstance(node_type, ast.List):
+            return List(type=self.resolve_type(node_type.value_type))
+        if isinstance(node_type, ast.Set):
+            return Set(type=self.resolve_type(node_type.value_type))
+        if isinstance(node_type, ast.Map):
+            return Map(
+                key_type=self.resolve_type(node_type.key_type),
+                value_type=self.resolve_type(node_type.value_type),
+            )
+        if node_type == "void":
+            return Void()
+
+        return type(node_type)
+
+    def parse_typedef(self, node):
+        typedef = TypeDef(name=node.name.value, type=self.resolve_type(node.type))
+
+        self.types_by_name[typedef.name] = typedef
+
+    def parse_enum(self, node):
+        values = [(x.name.value, x.tag) for x in node.values]
+
+        enum = Enum(name=node.name.value, values=values)
+
+        self.types_by_name[enum.name] = enum
+
+    def parse_struct(self, node):
+        fields = []
+
+        for field_ast in node.fields:
+            field = Field(
+                tag=field_ast.tag,
+                name=field_ast.name.value,
+                is_required=field_ast.required,
+                type=self.resolve_type(field_ast.type),
+            )
+
+            fields.append(field)
+
+        struct = Struct(name=node.name.value, fields=fields)
+
+        self.types_by_name[struct.name] = struct
+
+    def parse_exception(self, node):
+        fields = []
+
+        for field_ast in node.fields:
+            field = Field(
+                tag=field_ast.tag,
+                name=field_ast.name.value,
+                is_required=field_ast.required,
+                type=self.resolve_type(field_ast.type),
+            )
+
+            fields.append(field)
+
+        exc = Exc(name=node.name.value, fields=fields)
+
+        self.types_by_name[exc.name] = exc
+
+    def parse_function(self, node):
+        arguments = []
+
+        for argument_ast in node.arguments:
+            argument = Field(
+                tag=argument_ast.tag,
+                name=argument_ast.name.value,
+                is_required=True,
+                type=self.resolve_type(argument_ast.type),
+            )
+
+            arguments.append(argument)
+
+        throws = []
+
+        for throw_ast in node.throws:
+            throw = Field(
+                tag=throw_ast.tag,
+                name=throw_ast.name.value,
+                is_required=False,
+                type=self.resolve_type(throw_ast.type),
+            )
+
+            throws.append(throw)
+
+        function = Function(
+            name=node.name.value,
+            arguments=arguments,
+            type=self.resolve_type(node.type),
+            throws=throws,
+        )
+
+        # TODO check for name colisions
+        self.functions.append(function)
+
+    def parse_service(self, node):
+        for function in node.functions:
+            self.parse_function(function)
+
+    def parse_body(self, node):
+        for body_part in node:
+            if isinstance(body_part, ast.Typedef):
+                self.parse_typedef(body_part)
+            elif isinstance(body_part, ast.Enum):
+                self.parse_enum(body_part)
+            elif isinstance(body_part, ast.Struct):
+                self.parse_struct(body_part)
+            elif isinstance(body_part, ast.Exception_):
+                self.parse_exception(body_part)
+            elif isinstance(body_part, ast.Service):
+                self.parse_service(body_part)
+
+
+def parse_idl_file(path):
+    idl_parser = IdlParser()
+    idl_parser.parse_file(path)
+
+    return Idl(functions=idl_parser.functions)

--- a/thrift_tools/message_sniffer.py
+++ b/thrift_tools/message_sniffer.py
@@ -20,7 +20,10 @@ MessageSnifferOptions = namedtuple('MessageSnifferOptions', [
     'max_queued',
     'max_message_size',
     'debug',
+    'framed',
 ])
+# make framed optional for backward compatibility
+MessageSnifferOptions.__new__.__defaults__ = (False,)
 
 
 STOP_MESSAGE = object()
@@ -39,7 +42,8 @@ class MessageSniffer(Thread):
             finagle_thrift=options.finagle_thrift,
             max_message_size=options.max_message_size,
             read_values=options.read_values,
-            debug=options.debug)
+            debug=options.debug,
+            framed=options.framed)
 
         self._sniffer = Sniffer(
             options.iface, options.port,

--- a/thrift_tools/tests/resources/shared.thrift
+++ b/thrift_tools/tests/resources/shared.thrift
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This Thrift file can be included by other Thrift files that want to share
+ * these definitions.
+ */
+
+namespace cpp shared
+namespace d share // "shared" would collide with the eponymous D keyword.
+namespace dart shared
+namespace java shared
+namespace perl shared
+namespace php shared
+namespace haxe shared
+namespace netcore shared
+
+struct SharedStruct {
+  1: i32 key
+  2: string value
+}
+
+service SharedService {
+  SharedStruct getStruct(1: i32 key)
+}

--- a/thrift_tools/tests/resources/tutorial.thrift
+++ b/thrift_tools/tests/resources/tutorial.thrift
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+# Thrift Tutorial
+# Mark Slee (mcslee@facebook.com)
+#
+# This file aims to teach you how to use Thrift, in a .thrift file. Neato. The
+# first thing to notice is that .thrift files support standard shell comments.
+# This lets you make your thrift file executable and include your Thrift build
+# step on the top line. And you can place comments like this anywhere you like.
+#
+# Before running this file, you will need to have installed the thrift compiler
+# into /usr/local/bin.
+
+/**
+ * The first thing to know about are types. The available types in Thrift are:
+ *
+ *  bool        Boolean, one byte
+ *  i8 (byte)   Signed 8-bit integer
+ *  i16         Signed 16-bit integer
+ *  i32         Signed 32-bit integer
+ *  i64         Signed 64-bit integer
+ *  double      64-bit floating point value
+ *  string      String
+ *  binary      Blob (byte array)
+ *  map<t1,t2>  Map from one type to another
+ *  list<t1>    Ordered list of one type
+ *  set<t1>     Set of unique elements of one type
+ *
+ * Did you also notice that Thrift supports C style comments?
+ */
+
+// Just in case you were wondering... yes. We support simple C comments too.
+
+/**
+ * Thrift files can reference other Thrift files to include common struct
+ * and service definitions. These are found using the current path, or by
+ * searching relative to any paths specified with the -I compiler flag.
+ *
+ * Included objects are accessed using the name of the .thrift file as a
+ * prefix. i.e. shared.SharedObject
+ */
+include "shared.thrift"
+
+/**
+ * Thrift files can namespace, package, or prefix their output in various
+ * target languages.
+ */
+namespace cpp tutorial
+namespace d tutorial
+namespace dart tutorial
+namespace java tutorial
+namespace php tutorial
+namespace perl tutorial
+namespace haxe tutorial
+namespace netcore tutorial
+
+/**
+ * Thrift lets you do typedefs to get pretty names for your types. Standard
+ * C style here.
+ */
+typedef i32 MyInteger
+
+/**
+ * Thrift also lets you define constants for use across languages. Complex
+ * types and structs are specified using JSON notation.
+ */
+const i32 INT32CONSTANT = 9853
+const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
+
+/**
+ * You can define enums, which are just 32 bit integers. Values are optional
+ * and start at 1 if not supplied, C style again.
+ */
+enum Operation {
+  ADD = 1,
+  SUBTRACT = 2,
+  MULTIPLY = 3,
+  DIVIDE = 4
+}
+
+/**
+ * Structs are the basic complex data structures. They are comprised of fields
+ * which each have an integer identifier, a type, a symbolic name, and an
+ * optional default value.
+ *
+ * Fields can be declared "optional", which ensures they will not be included
+ * in the serialized output if they aren't set.  Note that this requires some
+ * manual management in some languages.
+ */
+struct Work {
+  1: i32 num1 = 0,
+  2: i32 num2,
+  3: Operation op,
+  4: optional string comment,
+}
+
+/**
+ * Structs can also be exceptions, if they are nasty.
+ */
+exception InvalidOperation {
+  1: i32 whatOp,
+  2: string why
+}
+
+/**
+ * Ahh, now onto the cool part, defining a service. Services just need a name
+ * and can optionally inherit from another service using the extends keyword.
+ */
+service Calculator extends shared.SharedService {
+
+  /**
+   * A method definition looks like C code. It has a return type, arguments,
+   * and optionally a list of exceptions that it may throw. Note that argument
+   * lists and exception lists are specified using the exact same syntax as
+   * field lists in struct or exception definitions.
+   */
+
+   void ping(),
+
+   i32 add(1:i32 num1, 2:i32 num2),
+
+   i32 calculate(1:i32 logid, 2:Work w) throws (1:InvalidOperation ouch),
+
+   /**
+    * This method has a oneway modifier. That means the client only makes
+    * a request and does not listen for any response at all. Oneway methods
+    * must be void.
+    */
+   oneway void zip()
+
+}
+
+/**
+ * That just about covers the basics. Take a look in the test/ folder for more
+ * detailed examples. After you run this file, your generated code shows up
+ * in folders with names gen-<language>. The generated code isn't too scary
+ * to look at. It even has pretty indentation.
+ */

--- a/thrift_tools/tests/test_idl.py
+++ b/thrift_tools/tests/test_idl.py
@@ -1,0 +1,132 @@
+import unittest
+
+import ptsd.ast
+from thrift_tools import idl
+
+from .util import get_thrift_path
+
+
+class IdlTestCase(unittest.TestCase):
+    maxDiff = None
+
+    def test_parse_idl_file(self):
+        parsed = idl.parse_idl_file(get_thrift_path("tutorial"))
+
+        self.assertEqual(
+            parsed.functions,
+            [
+                idl.Function(
+                    name="getStruct",
+                    arguments=[
+                        idl.Field(
+                            is_required=True, name="key", tag=1, type=ptsd.ast.I32
+                        )
+                    ],
+                    type=idl.Struct(
+                        fields=[
+                            idl.Field(
+                                is_required=False, name="key", tag=1, type=ptsd.ast.I32
+                            ),
+                            idl.Field(
+                                is_required=False,
+                                name="value",
+                                tag=2,
+                                type=ptsd.ast.String,
+                            ),
+                        ],
+                        name="SharedStruct",
+                    ),
+                    throws=[],
+                ),
+                idl.Function(name="ping", type=idl.Void(), arguments=[], throws=[]),
+                idl.Function(
+                    name="add",
+                    arguments=[
+                        idl.Field(
+                            is_required=True, name="num1", tag=1, type=ptsd.ast.I32
+                        ),
+                        idl.Field(
+                            is_required=True, name="num2", tag=2, type=ptsd.ast.I32
+                        ),
+                    ],
+                    type=ptsd.ast.I32,
+                    throws=[],
+                ),
+                idl.Function(
+                    name="calculate",
+                    arguments=[
+                        idl.Field(
+                            is_required=True, name="logid", tag=1, type=ptsd.ast.I32
+                        ),
+                        idl.Field(
+                            is_required=True,
+                            name="w",
+                            tag=2,
+                            type=idl.Struct(
+                                fields=[
+                                    idl.Field(
+                                        is_required=False,
+                                        name="num1",
+                                        tag=1,
+                                        type=ptsd.ast.I32,
+                                    ),
+                                    idl.Field(
+                                        is_required=False,
+                                        name="num2",
+                                        tag=2,
+                                        type=ptsd.ast.I32,
+                                    ),
+                                    idl.Field(
+                                        is_required=False,
+                                        name="op",
+                                        tag=3,
+                                        type=idl.Enum(
+                                            name="Operation",
+                                            values=[
+                                                ("ADD", 1),
+                                                ("SUBTRACT", 2),
+                                                ("MULTIPLY", 3),
+                                                ("DIVIDE", 4),
+                                            ],
+                                        ),
+                                    ),
+                                    idl.Field(
+                                        is_required=False,
+                                        name="comment",
+                                        tag=4,
+                                        type=ptsd.ast.String,
+                                    ),
+                                ],
+                                name="Work",
+                            ),
+                        ),
+                    ],
+                    type=ptsd.ast.I32,
+                    throws=[
+                        idl.Field(
+                            is_required=False,
+                            name="ouch",
+                            tag=1,
+                            type=idl.Exc(
+                                name="InvalidOperation",
+                                fields=[
+                                    idl.Field(
+                                        is_required=False,
+                                        name="whatOp",
+                                        tag=1,
+                                        type=ptsd.ast.I32,
+                                    ),
+                                    idl.Field(
+                                        is_required=False,
+                                        name="why",
+                                        tag=2,
+                                        type=ptsd.ast.String,
+                                    ),
+                                ],
+                            ),
+                        )
+                    ],
+                ),
+                idl.Function(name="zip", arguments=[], type=idl.Void(), throws=[]),
+            ],
+        )

--- a/thrift_tools/tests/test_printer.py
+++ b/thrift_tools/tests/test_printer.py
@@ -3,14 +3,16 @@ try:
 except ImportError:
     from io import StringIO
 
+import re
 import unittest
 
 from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift_tools import idl
 from thrift_tools.message_sniffer import MessageSnifferOptions, MessageSniffer
 from thrift_tools.printer import (
     FormatOptions, LatencyPrinter, PairedPrinter, Printer)
 
-from .util import get_pcap_path
+from .util import get_pcap_path, get_thrift_path
 
 
 def options():
@@ -27,13 +29,14 @@ def options():
         debug=False)
 
 
-def format_options():
+def format_options(show_fields=False, idl_file=None):
     return FormatOptions(
         pretty_printer=False,
         is_color=False,
         show_header=False,
-        show_fields=False,
+        show_fields=show_fields,
         json=False,
+        idl_file=idl_file
         )
 
 
@@ -114,3 +117,42 @@ class PrinterTestCase(unittest.TestCase):
         self.assertIn(
             '127.0.0.1:9090 -> 127.0.0.1:51112: method=getStruct, type=reply, seqid=0\n',
             output.getvalue())
+
+    def test_paired_idl(self):
+        output = StringIO()
+        format_opts = format_options(
+            show_fields=True,
+            idl_file=get_thrift_path('tutorial'),
+        )
+        printer = PairedPrinter(format_opts, output)
+
+        message_sniffer = MessageSniffer(options(), printer)
+        message_sniffer.join()
+
+        out = '\n'.join(
+            re.sub(r'\[\d+:\d+:\d+:\d+\] ', '', line)
+            for line in output.getvalue().splitlines()
+        )
+        expected = '\n'.join([
+            "127.0.0.1:51112 -> 127.0.0.1:9090: method=ping, type=call, seqid=0",
+            "fields: []",
+            "------>127.0.0.1:9090 -> 127.0.0.1:51112: method=ping, type=reply, seqid=0",
+            "        fields: fields=[]",
+            "127.0.0.1:51112 -> 127.0.0.1:9090: method=add, type=call, seqid=0",
+            "fields: [('num1', 1), ('num2', 1)]",
+            "------>127.0.0.1:9090 -> 127.0.0.1:51112: method=add, type=reply, seqid=0",
+            "        fields: 2",
+            "127.0.0.1:51112 -> 127.0.0.1:9090: method=calculate, type=call, seqid=0",
+            "fields: [('logid', 1), ('w', ('Work', [('num1', 1), ('num2', 0), ('op', 'DIVIDE'), ('comment', None)]))]",
+            "------>127.0.0.1:9090 -> 127.0.0.1:51112: method=calculate, type=reply, seqid=0",
+            "        fields: ('InvalidOperation', [('whatOp', 4), ('why', 'Cannot divide by 0')])",
+            "127.0.0.1:51112 -> 127.0.0.1:9090: method=calculate, type=call, seqid=0",
+            "fields: [('logid', 1), ('w', ('Work', [('num1', 15), ('num2', 10), ('op', 'SUBTRACT'), ('comment', None)]))]",
+            "------>127.0.0.1:9090 -> 127.0.0.1:51112: method=calculate, type=reply, seqid=0",
+            "        fields: 5",
+            "127.0.0.1:51112 -> 127.0.0.1:9090: method=getStruct, type=call, seqid=0",
+            "fields: [('key', 1)]",
+            "------>127.0.0.1:9090 -> 127.0.0.1:51112: method=getStruct, type=reply, seqid=0",
+            "        fields: ('SharedStruct', [('key', 1), ('value', '5')])",
+        ])
+        self.assertEqual(out, expected)

--- a/thrift_tools/tests/util.py
+++ b/thrift_tools/tests/util.py
@@ -12,3 +12,7 @@ def get_pcap_path(capture_file):
 
 def get_log_path(log_file):
     return os.path.join(_resources_dir, '%s.logfile' % (log_file))
+
+
+def get_thrift_path(thrift_file):
+    return os.path.join(_resources_dir, '%s.thrift' % (thrift_file))

--- a/thrift_tools/thrift_message.py
+++ b/thrift_tools/thrift_message.py
@@ -76,9 +76,9 @@ class ThriftMessage(object):
 
     # some sane defaults to keep memory usage tight
     MAX_FIELDS = 1000
-    MAX_LIST_SIZE = 10000
-    MAX_MAP_SIZE = 10000
-    MAX_SET_SIZE = 10000
+    MAX_LIST_SIZE = 1000000
+    MAX_MAP_SIZE = 1000000
+    MAX_SET_SIZE = 1000000
 
     @classmethod
     def read(cls, data,

--- a/thrift_tools/tool.py
+++ b/thrift_tools/tool.py
@@ -69,6 +69,8 @@ def get_flags():  # pragma: no cover
                       help='Shows header, fields and values')
     dump.add_argument('--json', default=False, action='store_true',
                       help='Outputs messages as JSON')
+    dump.add_argument('--idl-file', type=str, default='',
+                   help='Use .thrift file to resolve types')
 
     # stats
     stats = cmds.add_parser('stats')
@@ -94,6 +96,7 @@ def main():
             flags.show_header or flags.show_all,
             flags.show_fields or flags.show_all,
             flags.json,
+            flags.idl_file,
             )
         printer = printer_cls(format_opts)
         read_values = flags.show_values or flags.show_all

--- a/thrift_tools/tool.py
+++ b/thrift_tools/tool.py
@@ -118,9 +118,11 @@ def main():
         print('Valid options for --protocol are: %s' % VALID_PROTOCOLS)
         sys.exit(1)
 
+    iface = None if flags.pcap_file else flags.iface
+
     # launch the thrift message sniffer
     options = MessageSnifferOptions(
-        iface=flags.iface,
+        iface=iface,
         port=flags.port,
         ip=flags.ip,
         pcap_file=flags.pcap_file,

--- a/thrift_tools/tool.py
+++ b/thrift_tools/tool.py
@@ -40,6 +40,8 @@ def get_flags():  # pragma: no cover
                    help='Path to pcap file, for offline introspection')
     p.add_argument('--debug', default=False, action='store_true',
                    help='Display debugging messages')
+    p.add_argument('--framed', default=False, action='store_true',
+                   help='Framed Thrift transport')
     p.add_argument('--protocol', type=str, default='auto',
                    help='Use a specific protocol. Options: %s' %
                    VALID_PROTOCOLS)
@@ -124,7 +126,8 @@ def main():
         read_values=read_values,
         max_queued=flags.max_queued,
         max_message_size=flags.max_message_size,
-        debug=flags.debug
+        debug=flags.debug,
+        framed=flags.framed,
         )
     message_sniffer = MessageSniffer(options, printer)
 


### PR DESCRIPTION
This PR adds support for `.thrift` IDL file parsing and printing. Code is not optimized for performance and could use some cleaning up.

This PR adds library [ptsd](https://github.com/wickman/ptsd) sources because the library is not maintained anymore. Code was added with [author's permission](https://twitter.com/bancek/status/1166392003145424896).

New files are formatted using [black](https://github.com/psf/black) formatter and code is compatible with Python 3.

This PR closes #11.

Example output:

```sh
FROM_SOURCE=1 bin/thrift-tool --port 9090 --pcap-file thrift_tools/tests/resources/calc-service-binary.pcap dump --show-all --pretty --idl-file=thrift_tools/tests/resources/tutorial.thrift
reading from file thrift_tools/tests/resources/calc-service-binary.pcap, link-type EN10MB (Ethernet)
[00:55:50:387214] 127.0.0.1:51112 -> 127.0.0.1:9090: method=ping, type=call, seqid=0
header: None
fields: []
------>[00:55:50:387370] 127.0.0.1:9090 -> 127.0.0.1:51112: method=ping, type=reply, seqid=0
        header: None
        fields: fields=[]
[00:55:50:387492] 127.0.0.1:51112 -> 127.0.0.1:9090: method=add, type=call, seqid=0
header: None
fields: [('num1', 1), ('num2', 1)]
------>[00:55:50:387596] 127.0.0.1:9090 -> 127.0.0.1:51112: method=add, type=reply, seqid=0
        header: None
        fields: 2
[00:55:50:387696] 127.0.0.1:51112 -> 127.0.0.1:9090: method=calculate, type=call, seqid=0
header: None
fields: [   ('logid', 1),
    (   'w',
        (   'Work',
            [('num1', 1), ('num2', 0), ('op', 'DIVIDE'), ('comment', None)]))]
------>[00:55:50:387840] 127.0.0.1:9090 -> 127.0.0.1:51112: method=calculate, type=reply, seqid=0
        header: None
        fields: ('InvalidOperation', [('whatOp', 4), ('why', 'Cannot divide by 0')])
[00:55:50:388615] 127.0.0.1:51112 -> 127.0.0.1:9090: method=calculate, type=call, seqid=0
header: None
fields: [   ('logid', 1),
    (   'w',
        (   'Work',
            [   ('num1', 15),
                ('num2', 10),
                ('op', 'SUBTRACT'),
                ('comment', None)]))]
------>[00:55:50:388725] 127.0.0.1:9090 -> 127.0.0.1:51112: method=calculate, type=reply, seqid=0
        header: None
        fields: 5
[00:55:50:388811] 127.0.0.1:51112 -> 127.0.0.1:9090: method=getStruct, type=call, seqid=0
header: None
fields: [('key', 1)]
------>[00:55:50:388905] 127.0.0.1:9090 -> 127.0.0.1:51112: method=getStruct, type=reply, seqid=0
        header: None
        fields: ('SharedStruct', [('key', 1), ('value', '5')])
```
